### PR TITLE
hotfix

### DIFF
--- a/tests/Unit/Controllers/ApiControllerTest.php
+++ b/tests/Unit/Controllers/ApiControllerTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Controllers;
 
 use Tests\TestCase;
 use Illuminate\Http\JsonResponse;
-use Hedonist\Http\Controllers\ApiController;
+use Hedonist\Http\Controllers\Api\ApiController;
 
 class ApiControllerTest extends TestCase
 {


### PR DESCRIPTION
В файле ApiControllerTest.php используется ApiController. Но так как namespace у последнего изменился - он теперь его не находит