### PR TITLE
Fix design of User lists page

### DIFF
--- a/frontend/src/components/userList/UserListsItem.vue
+++ b/frontend/src/components/userList/UserListsItem.vue
@@ -1,11 +1,15 @@
 <template>
     <div 
-        class="column is-one-third is-square user-list-container" 
+        class="column is-one-third-desktop is-one-third-tablet is-square user-list-container"
         v-if="show"
     >
         <div class="user-list-content">
-            <div class="user-list-name">{{ userList.list_name }}</div>
-            <div class="user-list-places-count">{{ userList.places_count }} places saved in the list</div>
+            <div class="user-list-name">{{
+                userList.list_name
+            }}</div>
+            <div class="user-list-places-count">{{
+                userList.places_count
+            }} places saved in the list</div>
             <div class="user-list-button-wrap">
                 <div 
                     class="button is-info user-list-button-show-places" 
@@ -15,8 +19,10 @@
                 </div>
             </div>
         </div>
-        <figure class="image is-square">
-            <img :src="userList.img_preview.url">
+        <figure class="image is-square image-wrap">
+            <img
+                :src="userList.img_preview.url"
+            >
         </figure>
     </div>
 </template>
@@ -59,6 +65,19 @@ export default {
 <style lang="scss" scoped>
     .user-list-container {
         position: relative;
+        max-width: 341px;
+    }
+    @media (max-width: 845px) {
+        .user-list-container {
+            margin-left: auto;
+            margin-right: auto;
+        }
+    }
+    @media (min-width: 520px) and (max-width: 845px) {
+        .user-list-container {
+            flex: none;
+            width: 50% !important;
+        }
     }
     .user-list-content {
         z-index: 1;
@@ -81,5 +100,9 @@ export default {
     }
     .user-list-button-show-places {
         text-shadow: none;
+    }
+    .image-wrap {
+        border-radius: 5px;
+        overflow: hidden;
     }
 </style>

--- a/frontend/src/components/userList/UserListsList.vue
+++ b/frontend/src/components/userList/UserListsList.vue
@@ -65,6 +65,7 @@ export default {
 <style lang="scss" scoped>
     section {
         background: #FFF;
+        min-height: calc(100vh - 42px);
     }
 
     li {
@@ -80,6 +81,33 @@ export default {
         width: 10%;
         text-align: center;
         color: grey;
+    }
+
+    @media  (max-width: 1223px) {
+        .columns {
+            padding-top: 2.5rem;
+            padding-left: 1.5rem;
+            padding-right: 1.5rem;
+        }
+    }
+
+    @media  (min-width: 1224px) {
+        .columns {
+            padding-top: 2.5rem;
+            padding-left: calc((100% - 300px * 3) / 2);
+            padding-right: calc((100% - 300px * 3) / 2);
+        }
+    }
+
+    @media (min-width: 520px) and (max-width: 845px) {
+
+
+        .columns.is-multiline {
+            -ms-flex-wrap: wrap;
+            flex-wrap: wrap;
+            display: flex;
+            height: 100vh;
+        }
     }
 
 </style>


### PR DESCRIPTION
1. The list photo is displayed too big when the view port width is changed to 768px
https://trello.com/c/QYd1ikWG/241-the-list-photo-is-displayed-too-big-when-the-view-port-width-is-changed-to-768px
2. Add padding to my lists page
https://trello.com/c/wRYSseCf/226-add-padding-to-my-lists-page