### PR TITLE
fix/max_amount_of_slider_images: decrement by 1

### DIFF
--- a/frontend/src/components/place/PlacePhotoList.vue
+++ b/frontend/src/components/place/PlacePhotoList.vue
@@ -42,7 +42,7 @@ export default {
             photoList: null,
             imageOffset: null,
             imageSlideNumber: 2,
-            maxImages: 12
+            maxImages: 11
         };
     },
     mounted() {


### PR DESCRIPTION
to button been shown we need to have amount of photo bigger than slider can consist. So if we had 12 photos on each place - max amount of slider images should be 11