### PR TITLE
Feature/yarn: add optimized config for development. Command: "yarn run fast"

### DIFF
--- a/frontend/build/webpack.dev-fast.conf.js
+++ b/frontend/build/webpack.dev-fast.conf.js
@@ -1,0 +1,86 @@
+'use strict'
+const utils = require('./utils')
+const webpack = require('webpack')
+const config = require('../config')
+const merge = require('webpack-merge')
+const path = require('path')
+const baseWebpackConfig = require('./webpack.base.conf')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')
+const portfinder = require('portfinder')
+
+const HOST = process.env.HOST
+const PORT = process.env.PORT && Number(process.env.PORT)
+
+const devWebpackConfig = merge(baseWebpackConfig, {
+  module: {
+    rules: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap, usePostCSS: true })
+  },
+  // cheap-module-eval-source-map is faster for development
+  devtool: config.dev.devtool,
+
+  // these devServer options should be customized in /config/index.js
+  devServer: {
+    clientLogLevel: 'warning',
+    historyApiFallback: {
+      rewrites: [
+        { from: /.*/, to: path.posix.join(config.dev.assetsPublicPath, 'index.html') },
+      ],
+    },
+    hot: true,
+    contentBase: path.join(__dirname, 'dist'),
+    compress: true,
+    host: HOST || config.dev.host,
+    port: PORT || config.dev.port,
+    open: config.dev.autoOpenBrowser,
+    overlay: config.dev.errorOverlay
+      ? { warnings: false, errors: true }
+      : false,
+    publicPath: config.dev.assetsPublicPath,
+    proxy: config.dev.proxyTable,
+    quiet: true, // necessary for FriendlyErrorsPlugin
+    watchOptions: {
+      ignored: /node_modules/,
+      aggregateTimeout: 300,
+      poll: 1000,
+    }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': require('../config/dev.env')
+    }),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NamedModulesPlugin(), // HMR shows correct file names in console on update.
+    new webpack.NoEmitOnErrorsPlugin(),
+    new webpack.ProvidePlugin({
+      mapboxgl: 'mapbox-gl'
+    })
+  ]
+})
+
+module.exports = new Promise((resolve, reject) => {
+  portfinder.basePort = process.env.PORT || config.dev.port
+  portfinder.getPort((err, port) => {
+    if (err) {
+      reject(err)
+    } else {
+      // publish the new Port, necessary for e2e tests
+      process.env.PORT = port
+      // add port to devServer config
+      devWebpackConfig.devServer.port = port
+
+      // Add FriendlyErrorsPlugin
+      devWebpackConfig.plugins.push(new FriendlyErrorsPlugin({
+        compilationSuccessInfo: {
+          messages: [`Your application is running here: http://${devWebpackConfig.devServer.host}:${port}`],
+        },
+        onErrors: config.dev.notifyOnErrors
+        ? utils.createNotifierCallback()
+        : undefined
+      }))
+
+      resolve(devWebpackConfig)
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "author": "Pavlo Nemchenko <pavlo.nemchenko@binary-studio.com>",
     "scripts": {
         "dev": "webpack-dev-server --inline --progress --config frontend/build/webpack.dev.conf.js",
+        "fast": "webpack-dev-server --inline --progress --config frontend/build/webpack.dev-fast.conf.js",
         "start": "yarn run dev",
         "prod": "node frontend/build/build.js",
         "lint": "eslint --ext .js,.vue frontend/src",


### PR DESCRIPTION
https://trello.com/c/u6smD3R3/376-suggestion-optimized-webpack-server-config-for-development

Add command "yarn run fast" to run webpack-server with optimized config for slow PC. On my PC  difference is more than obvious

![dev](https://user-images.githubusercontent.com/13941459/44577091-da0db880-a798-11e8-8456-051748718655.PNG)
![fast](https://user-images.githubusercontent.com/13941459/44577092-da0db880-a798-11e8-9fa8-6e83a57f1991.PNG)

