### PR TITLE
Fix/navbar_search_map: fix watch triggering

### DIFF
--- a/frontend/src/components/place/SearchPlace.vue
+++ b/frontend/src/components/place/SearchPlace.vue
@@ -114,12 +114,18 @@ export default {
     },
     watch: {
         isMapLoaded: function (oldVal, newVal) {
-            this.updateMap();
+            if (this.isPlacesLoaded) {
+                this.updateMap();
+            }
         },
         isPlacesLoaded: function (oldVal, newVal) {
-            this.updateMap();
+            if (this.isPlacesLoaded) {
+                this.updateMap();
+            }
         },
         '$route' (to, from) {
+            this.isPlacesLoaded = false;
+
             this.$store.dispatch('place/fetchPlaces', to.query)
                 .then(() => {
                     this.isPlacesLoaded = true;


### PR DESCRIPTION
https://trello.com/c/5OG8ZWke/402-search-page-search-results-are-not-displayed-on-the-map-after-the-search-button-is-clicked-on