### PR TITLE
hotfix/phone field accepts letters

### DIFF
--- a/frontend/src/services/common/phoneValidationService.js
+++ b/frontend/src/services/common/phoneValidationService.js
@@ -1,6 +1,6 @@
 const E164 = /\+\d+/;
 
-const digits = /d+/;
+const digits = /\d+/;
 
 const isDigits = (phone) => (phone.length >= 10 && phone.length <= 16 && digits.test(phone));
 


### PR DESCRIPTION
Fixed regexp, now phone number without plus at start is valid too