### PR TITLE
fix filters on search page

### DIFF
--- a/frontend/src/components/place/SearchFilterPlace.vue
+++ b/frontend/src/components/place/SearchFilterPlace.vue
@@ -23,6 +23,12 @@
 import { mapActions, mapGetters } from 'vuex';
 export default {
     name: 'SearchFilterPlace',
+    props: {
+        isPlacesLoaded: {
+            type: Boolean,
+            required: true
+        }
+    },
     data() {
         return {
             timeDelay: 0,
@@ -64,22 +70,30 @@ export default {
             initFilters: 'search/initFilters'
         }),
         checkFilter(index) {
+            if (!this.isPlacesLoaded) {
+                return;
+            }
             let filterPlaces = this.filterPlaces[index];
 
             if (filterPlaces.check === false) {
                 filterPlaces.isLoading = true;
-                setTimeout(()=>{
-                    filterPlaces.isLoading = false;
-                    filterPlaces.check = !filterPlaces.check;
-                    this.setFilters({[index]: filterPlaces.check});
-                }, 300);
+                filterPlaces.check = !filterPlaces.check;
+                this.setFilters({[index]: filterPlaces.check})
+                    .then(() => {
+                        setTimeout(() => {
+                            filterPlaces.isLoading = false;
+                        }, 300);
+                    });
+
             } else {
                 filterPlaces.check = !filterPlaces.check;
                 filterPlaces.isLoading = true;
-                setTimeout(()=> {
-                    filterPlaces.isLoading = false;
-                    this.setFilters({[index]: filterPlaces.check});
-                }, 300);
+                this.setFilters({[index]: filterPlaces.check})
+                    .then(() => {
+                        setTimeout(()=> {
+                            filterPlaces.isLoading = false;
+                        }, 300);
+                    });
             }
         },
         init() {

--- a/frontend/src/components/place/SearchPlace.vue
+++ b/frontend/src/components/place/SearchPlace.vue
@@ -1,7 +1,7 @@
 <template>
     <section class="columns">
         <section class="column is-half">
-            <SearchFilterPlace />
+            <SearchFilterPlace :is-places-loaded="isPlacesLoaded" />
             <CategoryTagsContainer
                 v-if="categoryTagsList.length"
                 :tags="categoryTagsList"


### PR DESCRIPTION
https://trello.com/c/a97LP2f1/512-search-page-the-filter-is-not-applied-if-the-filter-is-selected-before-the-search-page-is-loaded