### PR TITLE
Hotfix/dont_show_follow_btn_on_my_profile

### DIFF
--- a/frontend/src/components/users/GeneralInfo.vue
+++ b/frontend/src/components/users/GeneralInfo.vue
@@ -93,6 +93,7 @@
                         </ul>
 
                         <FollowButton
+                            v-if="shouldShowFollowBtn"
                             @followed="followEventHandler"
                             :followed="isFollowedByCurrentUser"
                             :name="userProfile.first_name"
@@ -150,6 +151,9 @@ export default {
         },
         avatar() {
             return this.userProfile.avatar_url || defaultImage;
+        },
+        shouldShowFollowBtn(){
+            return !(this.getAuthenticatedUser.id === parseInt(this.$route.params.id));
         }
     },
     methods: {


### PR DESCRIPTION
https://trello.com/c/cGUwiDF3/651-the-follow-button-should-not-be-displayed-if-the-users-own-profile-page-is-displayed