### PR TITLE
Hotfix/too many review search queries

### DIFF
--- a/frontend/src/components/review/ReviewList.vue
+++ b/frontend/src/components/review/ReviewList.vue
@@ -121,7 +121,7 @@ export default {
 
         searchReview: _.debounce(function () {
             this.initialLoad();
-        }, 250),
+        }, 1000),
 
         loadNextReviewsPage($state) {
             _.debounce(() => {


### PR DESCRIPTION
https://trello.com/c/UA2ytcUF/701-search-review-the-site-freezes-for-5-10-seconds-after-the-search-review-on-the-il-molino-place-page-is-performed