### PR TITLE
Fix/update search fields after page refresh

### DIFF
--- a/frontend/src/components/navbar/SearchCity.vue
+++ b/frontend/src/components/navbar/SearchCity.vue
@@ -89,6 +89,18 @@ export default {
                 this.findCity.query = this.$t('search.current_location');
                 this.selectedCity.center[0] = coordinates.lng;
                 this.selectedCity.center[1] = coordinates.lat;
+
+                if (this.$route.query.location !== undefined) {
+                    let currentLocation = coordinates.lng + ',' + coordinates.lat;
+                    if (currentLocation !== this.$route.query.location) {
+                        LocationService.getCityList(this.$route.query.location)
+                            .then((res) => {
+                                if (res.length) {
+                                    this.findCity.query = res[0].text;
+                                }
+                            });
+                    }
+                }
             })
             .catch(error => {
                 this.setLocationAvailable(false);

--- a/frontend/src/components/navbar/SearchPlaceCategory.vue
+++ b/frontend/src/components/navbar/SearchPlaceCategory.vue
@@ -55,7 +55,8 @@ export default {
     methods: {
         ...mapActions({
             loadCategoriesByName: 'search/loadCategories',
-            loadPlaces: 'search/loadPlaces'
+            loadPlaces: 'search/loadPlaces',
+            fetchCategory: 'category/fetchCategory'
         }),
         loadItems: _.debounce(function () {
             this.findItems.data = [];
@@ -110,7 +111,22 @@ export default {
     },
     created() {
         this.init();
-    }
+    },
+    watch: {
+        '$route.query.category': function(category) {
+            if (category !== undefined && this.findItems.query === '') {
+                this.fetchCategory(category)
+                    .then((res) => {
+                        this.findItems.query = res.name;
+                    });
+            }
+        },
+        '$route.query.name': function(name) {
+            if (name !== undefined && this.findItems.query === '') {
+                this.findItems.query = name;
+            }
+        }
+    },
 };
 </script>
 

--- a/frontend/src/store/modules/category/actions.js
+++ b/frontend/src/store/modules/category/actions.js
@@ -33,5 +33,13 @@ export default {
 
     deleteCategoryTags: ({commit}) => {
         commit('DELETE_CATEGORY_TAGS');
-    }
+    },
+
+    fetchCategory: (context, categoryId) => {
+        return new Promise((resolve, reject) => {
+            httpService.get(`/places/categories/${categoryId}`)
+                .then((result) => { resolve(result.data.data); })
+                .catch((error) => { reject(error); });
+        });
+    },
 };

--- a/frontend/src/store/modules/search/actions.js
+++ b/frontend/src/store/modules/search/actions.js
@@ -7,7 +7,7 @@ import { KIEV_LATITUDE, KIEV_LONGITUDE } from '@/services/location/positions';
 export default {
     updateStateFromQuery: ({commit, dispatch}, query) => {
         dispatch('setLoadingState', true);
-        if(query.name) commit('SET_SEARCH_PLACE', {name: query.name});
+        if(query.name) commit('SET_SEARCH_PLACE', query.name);
         if(query.page) commit('SET_PAGE', query.page);
         if(query.category) commit('SET_SEARCH_PLACE_CATEGORY', {id: query.category, name: ''});
         if (query.tags) {


### PR DESCRIPTION
https://trello.com/c/DjPSf8o1/704-search-page-the-category-and-the-location-fields-do-not-correspond-to-the-search-results-and-map-after-the-page-is-refreshed