### PR TITLE
DropdownMenuClose: close menu after click on item menu

### DIFF
--- a/frontend/src/components/navbar/TopNavbar.vue
+++ b/frontend/src/components/navbar/TopNavbar.vue
@@ -220,6 +220,9 @@ export default {
                         }
                     });
             }
+        },
+        '$route' () {
+            this.navIsActive = false;
         }
     },
     methods: {


### PR DESCRIPTION
https://trello.com/c/XkSd7EWX/695-header-dropdown-menu-should-be-closed-after-the-menu-item-is-clicked-on