### PR TITLE
MobileLoginPage: remove padding for more usability in page

### DIFF
--- a/frontend/src/components/auth/Container.vue
+++ b/frontend/src/components/auth/Container.vue
@@ -55,4 +55,9 @@ export default {
 .button-wide {
   width: 100%;
 }
+@media screen and (max-width: 414px) {
+    .box{
+        padding: 20px;
+    }
+}
 </style>


### PR DESCRIPTION
https://trello.com/c/Hj2eB6Eb/722-login-sign-up-pages-very-big-padding-in-mobile-version